### PR TITLE
Closes #40 Docs: Update loss function parameters for the TCR-sequencing module

### DIFF
--- a/__future7/BubbleSortRecursiveTest.java
+++ b/__future7/BubbleSortRecursiveTest.java
@@ -1,0 +1,8 @@
+package com.thealgorithms.sorts;
+
+public class BubbleSortRecursiveTest extends SortingAlgorithmTest {
+    @Override
+    SortAlgorithm getSortAlgorithm() {
+        return new BubbleSortRecursive();
+    }
+}

--- a/__future7/KNearestNeighbors.cs
+++ b/__future7/KNearestNeighbors.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Algorithms.MachineLearning;
+
+/// <summary>
+/// K-Nearest Neighbors (KNN) classifier implementation.
+/// This algorithm classifies data points based on the majority label of their k nearest neighbors.
+/// </summary>
+/// <typeparam name="TLabel">
+/// The type of the label used for classification. This can be any type that represents the class or category of a sample.
+/// </typeparam>
+public class KNearestNeighbors<TLabel>
+{
+    private readonly List<(double[] Features, TLabel Label)> trainingData = new();
+    private readonly int k;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KNearestNeighbors{TLabel}"/> classifier.
+    /// </summary>
+    /// <param name="k">Number of neighbors to consider for classification.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if k is less than 1.</exception>
+    public KNearestNeighbors(int k)
+    {
+        if (k < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(k), "k must be at least 1.");
+        }
+
+        this.k = k;
+    }
+
+    /// <summary>
+    /// Calculates the Euclidean distance between two feature vectors.
+    /// </summary>
+    /// <param name="a">First feature vector.</param>
+    /// <param name="b">Second feature vector.</param>
+    /// <returns>Euclidean distance.</returns>
+    /// <exception cref="ArgumentException">Thrown if vectors are of different lengths.</exception>
+    public static double EuclideanDistance(double[] a, double[] b)
+    {
+        if (a.Length != b.Length)
+        {
+            throw new ArgumentException("Feature vectors must be of the same length.");
+        }
+
+        double sum = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            double diff = a[i] - b[i];
+            sum += diff * diff;
+        }
+
+        return Math.Sqrt(sum);
+    }
+
+    /// <summary>
+    /// Adds a training sample to the classifier.
+    /// </summary>
+    /// <param name="features">Feature vector of the sample.</param>
+    /// <param name="label">Label of the sample.</param>
+    public void AddSample(double[] features, TLabel label)
+    {
+        if (features == null)
+        {
+            throw new ArgumentNullException(nameof(features));
+        }
+
+        trainingData.Add((features, label));
+    }
+
+    /// <summary>
+    /// Predicts the label for a given feature vector using the KNN algorithm.
+    /// </summary>
+    /// <param name="features">Feature vector to classify.</param>
+    /// <returns>Predicted label.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if there is no training data.</exception>
+    public TLabel Predict(double[] features)
+    {
+        if (trainingData.Count == 0)
+        {
+            throw new InvalidOperationException("No training data available.");
+        }
+
+        if (features == null)
+        {
+            throw new ArgumentNullException(nameof(features));
+        }
+
+        // Compute distances to all training samples
+        var distances = trainingData
+            .Select(td => (Label: td.Label, Distance: EuclideanDistance(features, td.Features)))
+            .OrderBy(x => x.Distance)
+            .Take(k)
+            .ToList();
+
+        // Majority vote
+        var labelCounts = distances
+            .GroupBy(x => x.Label)
+            .Select(g => new { Label = g.Key, Count = g.Count(), MinDistance = g.Min(item => item.Distance) })
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.MinDistance)
+            .ToList();
+
+        return labelCounts.First().Label;
+    }
+}

--- a/__future7/PrintTopViewofTree.java
+++ b/__future7/PrintTopViewofTree.java
@@ -1,0 +1,117 @@
+package com.thealgorithms.datastructures.trees; // Java program to print top view of Binary tree
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+
+// Class for a tree node
+class TreeNode {
+
+    // Members
+
+    int key;
+    TreeNode left;
+    TreeNode right;
+
+    // Constructor
+    TreeNode(int key) {
+        this.key = key;
+        left = null;
+        right = null;
+    }
+}
+
+// A class to represent a queue item. The queue is used to do Level
+// order traversal. Every Queue item contains node and horizontal
+// distance of node from root
+class QItem {
+
+    TreeNode node;
+    int hd;
+
+    QItem(TreeNode n, int h) {
+        node = n;
+        hd = h;
+    }
+}
+
+// Class for a Binary Tree
+class Tree {
+
+    TreeNode root;
+
+    // Constructors
+    Tree() {
+        root = null;
+    }
+
+    Tree(TreeNode n) {
+        root = n;
+    }
+
+    // This method prints nodes in top view of binary tree
+    public void printTopView() {
+        // base case
+        if (root == null) {
+            return;
+        }
+
+        // Creates an empty hashset
+        HashSet<Integer> set = new HashSet<>();
+
+        // Create a queue and add root to it
+        Queue<QItem> queue = new LinkedList<QItem>();
+        queue.add(new QItem(root, 0)); // Horizontal distance of root is 0
+
+        // Standard BFS or level order traversal loop
+        while (!queue.isEmpty()) {
+            // Remove the front item and get its details
+            QItem qi = queue.remove();
+            int hd = qi.hd;
+            TreeNode n = qi.node;
+
+            // If this is the first node at its horizontal distance,
+            // then this node is in top view
+            if (!set.contains(hd)) {
+                set.add(hd);
+                System.out.print(n.key + " ");
+            }
+
+            // Enqueue left and right children of current node
+            if (n.left != null) {
+                queue.add(new QItem(n.left, hd - 1));
+            }
+            if (n.right != null) {
+                queue.add(new QItem(n.right, hd + 1));
+            }
+        }
+    }
+}
+
+// Driver class to test above methods
+public final class PrintTopViewofTree {
+    private PrintTopViewofTree() {
+    }
+
+    public static void main(String[] args) {
+        /* Create following Binary Tree
+       1
+     /  \
+    2    3
+     \
+      4
+       \
+        5
+         \
+          6*/
+        TreeNode root = new TreeNode(1);
+        root.left = new TreeNode(2);
+        root.right = new TreeNode(3);
+        root.left.right = new TreeNode(4);
+        root.left.right.right = new TreeNode(5);
+        root.left.right.right.right = new TreeNode(6);
+        Tree t = new Tree(root);
+        System.out.println("Following are nodes in top view of Binary Tree");
+        t.printTopView();
+    }
+}

--- a/__future7/SimplifiedWiggleSort.test.js
+++ b/__future7/SimplifiedWiggleSort.test.js
@@ -1,0 +1,27 @@
+import { simplifiedWiggleSort } from '../SimplifiedWiggleSort.js'
+
+describe('simplified wiggle sort', () => {
+  test('simplified wiggle sort for chars', () => {
+    const src = ['a', 'b', 'c']
+    expect(simplifiedWiggleSort(src)).toEqual(['a', 'c', 'b'])
+  })
+
+  test('wiggle sort with duplicates, even array', () => {
+    const src = [2, 2, 1, 3]
+    expect(simplifiedWiggleSort(src)).toEqual([1, 3, 2, 2])
+  })
+
+  test('wiggle sort with duplicates, odd array', () => {
+    const src = [1, 1, 1, 2, 4]
+    expect(simplifiedWiggleSort(src)).toEqual([1, 4, 1, 2, 1])
+  })
+
+  test(
+    'simplified wiggle sort which leads to equal values next to ' +
+      'each other',
+    () => {
+      const src = [3, 3, 5, 1]
+      expect(simplifiedWiggleSort(src)).toEqual([1, 5, 3, 3])
+    }
+  )
+})

--- a/__future7/number_of_digits.ts
+++ b/__future7/number_of_digits.ts
@@ -1,0 +1,18 @@
+/**
+ * @function numberOfDigits
+ * @description Calculate the number of digits of a natural number.
+ * @param {number} num - A natural number.
+ * @return {number} - Number of digits of given natural number.
+ * @see https://math.stackexchange.com/a/231745/518862
+ * @example numberOfDigits(18) = 2
+ * @example numberOfDigits(294568) = 6
+ * @example numberOfDigits(128798319794) = 12
+ */
+
+export const numberOfDigits = (num: number): number => {
+  if (num <= 0 || !Number.isInteger(num)) {
+    throw new Error('only natural numbers are supported')
+  }
+
+  return Math.floor(Math.log10(num)) + 1
+}

--- a/__future7/tanh.rs
+++ b/__future7/tanh.rs
@@ -1,0 +1,34 @@
+//Rust implementation of the Tanh (hyperbolic tangent) activation function.
+//The formula for Tanh: (e^x - e^(-x))/(e^x + e^(-x)) OR (2/(1+e^(-2x))-1
+//More information on the concepts of Sigmoid can be found here:
+//https://en.wikipedia.org/wiki/Hyperbolic_functions
+
+//The function below takes a reference to a mutable <f32> Vector as an argument
+//and returns the vector with 'Tanh' applied to all values.
+//Of course, these functions can be changed by the developer so that the input vector isn't manipulated.
+//This is simply an implemenation of the formula.
+
+use std::f32::consts::E;
+
+pub fn tanh(array: &mut Vec<f32>) -> &mut Vec<f32> {
+    //note that these calculations are assuming the Vector values consists of real numbers in radians
+    for value in &mut *array {
+        *value = (2. / (1. + E.powf(-2. * *value))) - 1.;
+    }
+
+    array
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tanh() {
+        let mut test = Vec::from([1.0, 0.5, -1.0, 0.0, 0.3]);
+        assert_eq!(
+            tanh(&mut test),
+            &mut Vec::<f32>::from([0.76159406, 0.4621172, -0.7615941, 0.0, 0.29131258,])
+        );
+    }
+}


### PR DESCRIPTION
40 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.